### PR TITLE
adding histogram to color & filter controls

### DIFF
--- a/django_tutorial/first_project/web_app/.babelrc
+++ b/django_tutorial/first_project/web_app/.babelrc
@@ -1,4 +1,4 @@
 {
   "presets": ["es2015", "react"],
-  "plugins": ["transform-object-rest-spread"]
+  "plugins": ["transform-object-rest-spread", "transform-class-properties"]
 }

--- a/django_tutorial/first_project/web_app/package.json
+++ b/django_tutorial/first_project/web_app/package.json
@@ -19,6 +19,7 @@
     "babel-core": "^6.26.0",
     "babel-jest": "^20.0.3",
     "babel-loader": "^7.1.2",
+    "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-react": "^6.24.1",
@@ -30,6 +31,7 @@
     "webpack": "^3.5.5"
   },
   "dependencies": {
+    "d3": "^4.10.0",
     "isomorphic-fetch": "^2.2.1",
     "rc-slider": "^8.3.1",
     "react": "^15.6.1",

--- a/django_tutorial/first_project/web_app/static_src/css/style.css
+++ b/django_tutorial/first_project/web_app/static_src/css/style.css
@@ -48,3 +48,12 @@ html, body, #root, #root>div, #map { height: 100%; margin: 0; padding: 0; overfl
 .rc-slider {
   clear: both;
 }
+
+.histogram {
+  height: 100px;
+}
+
+.histogram, .slider-with-labels {
+  margin-left: 30px;
+  width: 200px;
+}

--- a/django_tutorial/first_project/web_app/static_src/js/redux/regions.js
+++ b/django_tutorial/first_project/web_app/static_src/js/redux/regions.js
@@ -93,7 +93,12 @@ export function setDistrictAndRegionType({selectedDistrict, selectedRegionType})
             sbaDatum[field] = parseFloat(sbaDatum[field])
           })
 
+          // HACK: remove a couple spurious data points from the set to get better looking histograms.
+          // TODO: we should be cleaning the data in the pipeline
+          sbaDatum.sba_per_small_bus = Math.min(1, sbaDatum.sba_per_small_bus)
+          
           regions[sbaDatum.region] = sbaDatum
+
         })
 
         // dispatch an action that will set the actual geometry & region data on the state

--- a/django_tutorial/first_project/web_app/static_src/js/utilities.js
+++ b/django_tutorial/first_project/web_app/static_src/js/utilities.js
@@ -105,3 +105,23 @@ export function getOrderedFields() {
 //     return fs[k](arguments[0][key], ...Array.prototype.slice.call(arguments, 1))
 //   }})))
 // }
+
+
+
+export function calculateColor(value, quantiler) {
+  // TODO: don't use a red/green color scheme!  use viridis instead?
+
+  var low = [5, 69, 54];  // color of smallest datum
+  var high = [151, 83, 34];   // color of largest datum
+
+  // delta represents where the value sits between the min and max
+  let quantile = quantiler.getQuantile(value)
+
+  var color = [];
+  for (var i = 0; i < 3; i++) {
+    // calculate an integer color based on the delta
+    color[i] = (high[i] - low[i]) * quantile / (quantiler.thresholds.length) + low[i];
+  }
+
+  return 'hsl(' + color[0] + ',' + color[1] + '%,' + color[2] + '%)'
+}

--- a/django_tutorial/first_project/web_app/static_src/js/views/components/RegionHistogram.js
+++ b/django_tutorial/first_project/web_app/static_src/js/views/components/RegionHistogram.js
@@ -1,0 +1,108 @@
+import React from 'react'
+
+import * as d3 from "d3";
+
+
+
+
+let nextId = 1
+const createNextId = () => nextId++
+
+
+/**
+ * React component that renders a histogram, using D3.
+ * 
+ * We don't really use React's lifecycle here; instead we use D3 for DOM updates.
+ * Thus our React render method is just a div, and the real work happens in componentDidMount (for
+ * initialization) and componentDidUpdate (to do the rendering when the state has changed)
+ */
+export default class RegionHistogram extends React.Component {
+
+  constructor(props) {
+  	super(props)
+    this.id = createNextId()
+  }
+
+  getDivId() {
+    return `histogram-${this.id}`
+  }
+
+  /**
+   * called by React after the DOM element is first added to the page; we use this to
+   * initialize the svg
+   */
+  componentDidMount() {
+    this.svg = d3.select(`#${this.getDivId()}`).append('svg')
+  }
+
+
+  /**
+   * called by React after each props/state update; we use this to tell d3 to re-render
+   */
+  componentDidUpdate(prevProps) {
+
+    // remove any nulls or NaNs from the data
+  	let data = this.props.data.filter(value => value != null && !isNaN(value))
+
+    // TODO for performance: as a quick hack we're currently just wiping and rebuilding the svg; instead
+    // we should have it just update the existing svg elements
+  	this.svg.remove()
+  	this.svg = d3.select(`#${this.getDivId()}`).append('svg')
+
+    // the following code is modified from the histogram example here: https://bl.ocks.org/mbostock/3048450
+
+	  let margin = {top: 10, right: 0, bottom: 30, left: 0}
+    let width = parseFloat(d3.select(`#${this.getDivId()}`).style("width")) - margin.left - margin.right
+    let height = parseFloat(d3.select(`#${this.getDivId()}`).style("height")) - margin.top - margin.bottom
+    let g = this.svg.append("g").attr("transform", "translate(" + margin.left + "," + margin.top + ")")
+
+    var x = d3.scaleLinear()
+    	.domain([Math.min(...data), Math.max(...data)])
+        .rangeRound([0, width]);
+
+    var bins = d3.histogram()
+        .domain(x.domain())
+        .thresholds(x.ticks(40))
+        (data);
+
+    var y = d3.scaleLinear()
+        .domain([0, d3.max(bins, function(d) { return d.length; })])
+        .range([height, 0]);
+
+    var bar = g.selectAll(".bar")
+      .data(bins)
+      .enter().append("g")
+        .attr("class", "bar")
+        .attr("transform", function(d) { return "translate(" + x(d.x0) + "," + y(d.length) + ")"; });
+
+    let rect = bar.append("rect")
+        .attr("x", 0)
+        .attr("width", d => x(d.x1) - x(d.x0))
+        .attr("height", function(d) { return height - y(d.length); });
+    if(this.props.colorFunction) {
+    	rect.attr("fill", d => this.props.colorFunction(d.x0))
+    }
+
+
+    g.append("g")
+        .attr("class", "axis axis--x")
+        .attr("transform", "translate(0," + height + ")")
+        .call(d3.axisBottom(x));
+
+    (this.props.lines || []).forEach(lineValue => {
+      g.append("line")
+        .attr("x1", x(lineValue))
+        .attr("x2", x(lineValue))
+        .attr("y1", 0)
+        .attr("y2", height)
+        .attr("stroke", "blue")
+    })
+  }
+
+
+
+  render() {
+    return <div className="histogram" id={this.getDivId()}/>
+  }
+}
+

--- a/django_tutorial/first_project/web_app/static_src/js/views/components/SliderWithHistogramAndLabels.js
+++ b/django_tutorial/first_project/web_app/static_src/js/views/components/SliderWithHistogramAndLabels.js
@@ -1,0 +1,39 @@
+import React from 'react'
+
+import { Range } from 'rc-slider'
+import 'rc-slider/assets/index.css';
+
+import { round } from '../../utilities'
+
+import RegionHistogram from './RegionHistogram'
+import SliderWithLabels from './SliderWithLabels'
+
+/**
+ * Wraps the rc-slider component with labels and a histogram showing the values being filtered
+ */
+export default class SliderWithHistogramAndLabels extends React.Component {
+
+  histogramColorFunction = (value) => {
+  	return this.props.filterRange[0] < value && value < this.props.filterRange[1]
+  	  ? '#000'
+  	  : '#aaa'
+  }
+
+  render() {
+    return (
+      <div>
+        <RegionHistogram
+          data={this.props.data}
+          colorFunction={this.histogramColorFunction}
+          lines={this.props.filterRange}/>
+        <SliderWithLabels
+          min={this.props.filterExtent[0]}
+          max={this.props.filterExtent[1]}
+          value={this.props.filterRange}
+          step={(this.props.filterExtent[1]-this.props.filterExtent[0])/100}
+          allowCross={false}
+          onChange={this.props.onChangeRange} />
+      </div>
+    )
+  }
+}

--- a/django_tutorial/first_project/web_app/static_src/js/views/components/SliderWithLabels.js
+++ b/django_tutorial/first_project/web_app/static_src/js/views/components/SliderWithLabels.js
@@ -10,7 +10,7 @@ import { round } from '../../utilities'
  */
 export default function SliderWithLabels(props) {
   return (
-    <div>
+    <div className="slider-with-labels">
       <div id="filter-min">{round(props.value[0], 1)}</div>
       <div id="filter-max">{round(props.value[1], 1)}</div>
       <Range {...props}/>

--- a/django_tutorial/first_project/web_app/static_src/js/views/containers/ColorControls.js
+++ b/django_tutorial/first_project/web_app/static_src/js/views/containers/ColorControls.js
@@ -1,10 +1,14 @@
 import React from 'react'
 import {connect} from 'react-redux'
 
-import { getColorState } from '../../redux/root'
-import {getColorField, setColorField} from '../../redux/color'
+import { getColorState, getRegionState } from '../../redux/root'
+import {getColorField, setColorField, getColorQuantiler} from '../../redux/color'
+import { getRegions, getMousedRegion } from '../../redux/regions'
+
+import { calculateColor } from '../../utilities'
 
 import FieldBox from '../components/FieldBox'
+import RegionHistogram from '../components/RegionHistogram'
 
 /*
  * React container for the color dropdown and controls.  Note that for now we
@@ -13,13 +17,30 @@ import FieldBox from '../components/FieldBox'
  */
 
 
+/**
+ * React container showing the color field selection, and color range slider
+ */
+function ColorControls(props) {
+  return (
+    <div>
+      <FieldBox title="Color By" value={props.field} onChange={props.onChangeField}/>
+      <RegionHistogram data={props.data} colorFunction={value => calculateColor(value, props.quantiler)}
+        lines={props.mousedRegion ? [props.mousedRegion[props.field]] : []}/>
+    </div>
+  )
+}
+
+
 const mapStateToProps = state => ({
-  title: 'Color By',
-  value: getColorField(getColorState(state))
+  field: getColorField(getColorState(state)),
+  quantiler: getColorQuantiler(getColorState(state)),
+  data: Object.values(getRegions(getRegionState(state))).map(region => region[getColorField(getColorState(state))]),	// TODO: memoize
+  mousedRegion: getMousedRegion(getRegionState(state))
 })
 
 const mapDispatchToProps = {
-  onChange: setColorField
+  onChangeField: setColorField
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(FieldBox)
+export default connect(mapStateToProps, mapDispatchToProps)(ColorControls)
+

--- a/django_tutorial/first_project/web_app/static_src/js/views/containers/FilterControls.js
+++ b/django_tutorial/first_project/web_app/static_src/js/views/containers/FilterControls.js
@@ -3,9 +3,10 @@ import {connect} from 'react-redux'
 
 import { getFilterState, getRegionState } from '../../redux/root'
 import {getFilterField, getFilterRange, getFieldExtent, setFilterField, setFilterRange} from '../../redux/filter'
+import { getRegions } from '../../redux/regions'
 
 import FieldBox from '../components/FieldBox'
-import SliderWithLabels from '../components/SliderWithLabels'
+import SliderWithHistogramAndLabels from '../components/SliderWithHistogramAndLabels'
 
 
 /**
@@ -15,9 +16,8 @@ function FilterControls(props) {
   return (
     <div>
       <FieldBox title="Filter By" value={props.field} onChange={props.onChangeField}/>
-      <SliderWithLabels min={props.filterExtent[0]} max={props.filterExtent[1]} value={props.filterRange}
-        step={(props.filterExtent[1]-props.filterExtent[0])/100}
-        allowCross={false} onChange={props.onChangeRange}/>
+      <SliderWithHistogramAndLabels filterExtent={props.filterExtent} filterRange={props.filterRange}
+        onChangeRange={props.onChangeRange} data={props.data}/>
     </div>
   )
 }
@@ -26,7 +26,8 @@ function FilterControls(props) {
 const mapStateToProps = state => ({
   field: getFilterField(getFilterState(state)),
   filterRange: getFilterRange(getFilterState(state)),
-  filterExtent: getFieldExtent(getRegionState(state), getFilterField(getFilterState(state)))
+  filterExtent: getFieldExtent(getRegionState(state), getFilterField(getFilterState(state))),
+  data: Object.values(getRegions(getRegionState(state))).map(region => region[getFilterField(getFilterState(state))]) // TODO: memoize
 })
 
 const mapDispatchToProps = {

--- a/django_tutorial/first_project/web_app/static_src/js/views/containers/GoogleMap.js
+++ b/django_tutorial/first_project/web_app/static_src/js/views/containers/GoogleMap.js
@@ -6,6 +6,8 @@ import {getGeometry, getRegions, setMousedRegionId} from '../../redux/regions'
 import {getColorField, getColorQuantiler, getNumColorQuantiles} from '../../redux/color'
 import {getFilterField, getFilterRange} from '../../redux/filter'
 
+import { calculateColor } from '../../utilities'
+
 
 /**
  * React component that renders the map with colored regions.  Basically a wrapper around the GoogleMap API.
@@ -114,20 +116,6 @@ export default connect(mapStateToProps, mapDispatchToProps)(GoogleMap)
  */
 function styleFeature(feature, props) {
 
-  // TODO: don't use a red/green color scheme!  use viridis instead?
-
-  var low = [5, 69, 54];  // color of smallest datum
-  var high = [151, 83, 34];   // color of largest datum
-
-  // delta represents where the value sits between the min and max
-  let quantile = props.colorQuantiler.getQuantile(feature.getProperty('colorVariable'))
-
-  var color = [];
-  for (var i = 0; i < 3; i++) {
-    // calculate an integer color based on the delta
-    color[i] = (high[i] - low[i]) * quantile / (props.numColorQuantiles - 1) + low[i];
-  }
-
   // determine whether to show this shape or not
   var showRow = true;
   if (feature.getProperty('colorVariable') == null ||
@@ -144,7 +132,7 @@ function styleFeature(feature, props) {
     strokeWeight: outlineWeight,
     strokeColor: '#fff',
     zIndex: zIndex,
-    fillColor: 'hsl(' + color[0] + ',' + color[1] + '%,' + color[2] + '%)',
+    fillColor: calculateColor(feature.getProperty('colorVariable'), props.colorQuantiler),
     fillOpacity: 0.75,
     visible: showRow
   };


### PR DESCRIPTION
**1. Brief Summary of what this PR accomplishes (140 characters or less. If you find trouble describing what you are doing in this length, consider breaking the PR into multiple ones.)**

Adds d3-powered histograms to the color & filter controls.

**2. Link to Trello Ticket**



**3. More detailed description and other questions to address in code review**

This is just a proof-of-concept I was hacking on during the session Wednesday night.  It shows it's pretty easy to incorporate d3-based visualizations into the React app.  The way I've done it isn't very performant (it ends up re-rendering the svg a lot) but in practice it seems good enough for now.
![screenshot from 2017-08-31 20-52-25](https://user-images.githubusercontent.com/6266431/29954675-8a1cc880-8e8e-11e7-92f3-400b25c44c0e.png)


**4. Remember to tag reviewers!**