### PR TITLE
adding in parse task for sandbox table

### DIFF
--- a/pipeline/pipeline_tasks/sandbox/parse_google_places_loan_data.py
+++ b/pipeline/pipeline_tasks/sandbox/parse_google_places_loan_data.py
@@ -6,7 +6,7 @@ That being said, just for the September 2017 MVP, we are going to use a "cleaned
 dataset that is already geocoded (somewhat manually) by Noah.
 
 Source of data:
-https://sfbrigade.slack.com/files/U317MMLE6/F403ZETLH/sfdo_504_7a-clean.csv
+https://files.slack.com/files-pri/T0431NL8C-F757ACNHM/download/sba_google_places_loan_data.csv
 """
 
 import argparse
@@ -31,9 +31,9 @@ def load_data(dbm, direc):
         dbm: DBManager object
         direc: Directory where files are
     """
-    df = pd.read_csv(os.path.join(direc, 'SFDO_504_7A-clean.csv'))
+    df = pd.read_csv(os.path.join(direc, 'sba_google_places_loan_data.csv'))
     dbm.write_df_table(
-        df, table_name='sba__sfdo_504_7a_clean', schema='sandbox')
+        df, table_name='sba__google_places_loan_data', schema='sandbox')
 
 
 def main():

--- a/pipeline/pipeline_tasks/sandbox/parse_sfdo_504_7a_clean.py
+++ b/pipeline/pipeline_tasks/sandbox/parse_sfdo_504_7a_clean.py
@@ -1,0 +1,51 @@
+"""
+Parsing SFDO 504 7a loan 'clean' dataset
+
+For the most part, we should be using data that we can reproduce from national FOIA datasets.
+That being said, just for the September 2017 MVP, we are going to use a "cleaned" version of the
+dataset that is already geocoded (somewhat manually) by Noah.
+
+Source of data:
+https://sfbrigade.slack.com/files/U317MMLE6/F403ZETLH/sfdo_504_7a-clean.csv
+"""
+
+import argparse
+import os
+
+import pandas as pd
+
+from utilities.db_manager import DBManager
+from utilities import util_functions as uf
+
+
+def get_args():
+    """Use argparse to parse command line arguments."""
+    parser = argparse.ArgumentParser(description='Runner for tasks')
+    parser.add_argument('--db_url', help='Database url string to the db.', required=True)
+    return parser.parse_args()
+
+
+def load_data(dbm, direc):
+    """Load census datasets
+    Keyword Args:
+        dbm: DBManager object
+        direc: Directory where files are
+    """
+    df = pd.read_csv(os.path.join(direc, 'SFDO_504_7A-clean.csv'))
+    dbm.write_df_table(
+        df, table_name='sba__sfdo_504_7a_clean', schema='sandbox')
+
+
+def main():
+    """Execute Stuff"""
+    print('Parsing SBA SFDO Clean dataset')
+    args = get_args()
+    dbm = DBManager(db_url=args.db_url)
+    git_root_dir = uf.get_git_root(os.path.dirname(__file__))
+    directory = os.path.join(git_root_dir, 'src', 'data', 'sba')
+    load_data(dbm, directory)
+
+
+if __name__ == '__main__':
+    """See https://stackoverflow.com/questions/419163/what-does-if-name-main-do"""
+    main()


### PR DESCRIPTION
**1. Brief Summary of what this PR accomplishes (140 characters or less. If you find trouble describing what you are doing in this length, consider breaking the PR into multiple ones.)**

Adding in geocoded loan dataset using Noah's "manually" cleaned data.

**2. Link to Trello Ticket**

https://trello.com/c/5hTzjejl/68-ingest-noahs-clean-csv-but-without-sfdo-specific-columns-at-least-get-lat-long-google-places-rating

**3. More detailed description and other questions to address in code review**

While we want to use national FOIA data set generally, since we're having some difficulty building out our geocoder module, just for the September 2017 MVP, we're going to take the dataset already geocoded by Noah and merge in the geocoded columns in. That way we can get going on our business level visualization.

In order to run the parser, you will need to add the dataset to `/src/data/sba`. Then run
```
python -m pipeline.pipeline_tasks.sandbox.parse_sfdo_504_7a_clean --db_url=$SBA_DWH
```

from the top-level directory. This will create the table `sandbox.sfdo_504_7a_clean`. This is in sandbox to denote that we don't want it to be part of our actual database moving forward, just for the MVP. 

You will then need to do a simple join to grab the columns you need.

**4. Remember to tag reviewers!**